### PR TITLE
fix: there is no such thing as a pr-message

### DIFF
--- a/.github/workflows/repo-rater.yml
+++ b/.github/workflows/repo-rater.yml
@@ -19,4 +19,4 @@ jobs:
       - uses: xkrishguptaa/action-repo-rater@v1.0.6
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          pr-message: "Thank you all for contributing to RepoRater! Please take a moment to rate this repo's DX on [EddieHub's RepoRater](https://repo-rater.eddiehub.io/rate?owner=${{ github.repository_owner }}&name=${{ github.event.repository.name }}) and give the repo a star ⭐"
+          message: "Thank you all for contributing to RepoRater! Please take a moment to rate this repo's DX on [EddieHub's RepoRater](https://repo-rater.eddiehub.io/rate?owner=${{ github.repository_owner }}&name=${{ github.event.repository.name }}) and give the repo a star ⭐"


### PR DESCRIPTION
Not sure how this got merged in 😅 It's a message. Also I think @eddiejaoude you need to enable the 'submit review on pr permission' in repository settings so that the action can comment on prs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the configuration parameter for the `action-repo-rater` GitHub Action to enhance automation workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->